### PR TITLE
Upgrade Bolt to 1.18.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 htmlcov
 .coverage
 .DS_Store
+.venv

--- a/multi_reaction_add/handlers.py
+++ b/multi_reaction_add/handlers.py
@@ -5,7 +5,9 @@ Attributes:
     storage_client (Client): client used to access Google Cloud Storage
     bucket (google.cloud.storage.bucket.Bucket): a GCS bucket for user data
     slack_client_id (str): Current Slack application client id
+    slash_command (str): What Slack slash command should the app listen to
     app (AsyncApp): Connector between Slack API and application logic
+    app_handler (AsyncSlackRequestHandler): ASGI compatible request handler
 """
 
 import os

--- a/multi_reaction_add/oauth/installation_store/google_cloud_storage/__init__.py
+++ b/multi_reaction_add/oauth/installation_store/google_cloud_storage/__init__.py
@@ -2,9 +2,6 @@
 """Store Slack bot install data to a Google Cloud Storage bucket.
 
 Adapted from https://github.com/slackapi/python-slack-sdk/blob/main/slack_sdk/oauth/installation_store/amazon_s3/__init__.py # pylint: disable=line-too-long
-
-Todo:
-    * must use is_enterprise_install argument when deleting
 """
 
 import json
@@ -175,7 +172,7 @@ class GoogleCloudStorageInstallationStore(InstallationStore, AsyncInstallationSt
         *,
         enterprise_id: Optional[str],
         team_id: Optional[str],
-        is_enterprise_install: Optional[bool] = False,  # pylint: disable=unused-argument
+        is_enterprise_install: Optional[bool] = False,
     ) -> Optional[Bot]:
         """Check if a Slack bot user has been installed in a Slack workspace.
 
@@ -190,6 +187,7 @@ class GoogleCloudStorageInstallationStore(InstallationStore, AsyncInstallationSt
         """
         key = self._key(data_type="bot",
             enterprise_id=enterprise_id,
+            is_enterprise_install=is_enterprise_install,
             team_id=team_id,
             user_id=None
         )
@@ -237,7 +235,7 @@ class GoogleCloudStorageInstallationStore(InstallationStore, AsyncInstallationSt
         enterprise_id: Optional[str],
         team_id: Optional[str],
         user_id: Optional[str] = None,
-        is_enterprise_install: Optional[bool] = False,  # pylint: disable=unused-argument
+        is_enterprise_install: Optional[bool] = False,
     ) -> Optional[Installation]:
         """Check if a Slack user has installed the app.
 
@@ -253,6 +251,7 @@ class GoogleCloudStorageInstallationStore(InstallationStore, AsyncInstallationSt
         """
         key = self._key(data_type="installer",
             enterprise_id=enterprise_id,
+            is_enterprise_install=is_enterprise_install,
             team_id=team_id,
             user_id=user_id
         )
@@ -375,7 +374,8 @@ class GoogleCloudStorageInstallationStore(InstallationStore, AsyncInstallationSt
         data_type: str,
         enterprise_id: Optional[str],
         team_id: Optional[str],
-        user_id: Optional[str]
+        user_id: Optional[str],
+        is_enterprise_install: Optional[bool] = None
     ) -> str:
         """Helper method to create a path to an object in a GCS bucket.
 
@@ -390,7 +390,7 @@ class GoogleCloudStorageInstallationStore(InstallationStore, AsyncInstallationSt
         """
         none = "none"
         e_id = enterprise_id or none
-        t_id = team_id or none
+        t_id = none if is_enterprise_install else team_id or none
 
         workspace_path = f"{self.client_id}/{e_id}-{t_id}"
         return (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-slack-bolt==1.16.2
+slack-bolt==1.18.0
 google-cloud-storage==2.7.0
 uvicorn==0.20.0
 aiohttp==3.8.5
@@ -6,4 +6,4 @@ starlette==0.28.0
 python-json-logger==2.0.4
 
 # pin the sdk dependency of bolt
-slack-sdk==3.19.5
+slack-sdk==3.21.2

--- a/tests/test_installation_store.py
+++ b/tests/test_installation_store.py
@@ -37,10 +37,14 @@ class TestGoogleInstallationStore(unittest.IsolatedAsyncioTestCase):
             client_id=self.client_id,
             logger=self.logger)
 
-        self.installation = Installation(user_id="uid",
-            team_id="tid",
+        self.entr_installation = Installation(user_id="uid",
+            team_id=None,
             is_enterprise_install=True,
             enterprise_id="eid")
+        self.team_installation = Installation(user_id="uid",
+            team_id="tid",
+            is_enterprise_install=False,
+            enterprise_id=None)
 
     def test_get_logger(self):
         """Test get_logger method"""
@@ -48,37 +52,37 @@ class TestGoogleInstallationStore(unittest.IsolatedAsyncioTestCase):
 
     @patch("multi_reaction_add.oauth.installation_store.google_cloud_storage."
            "GoogleCloudStorageInstallationStore._save_entity")
-    async def test_async_save(self, save_entity: Mock):
+    async def test_async_save_install(self, save_entity: Mock):
         """Test async_save method"""
-        await self.installation_store.async_save(self.installation)
+        await self.installation_store.async_save(self.entr_installation)
         self.storage_client.bucket.assert_called_once_with(self.bucket_name)
         save_entity.assert_has_calls([
             call(data_type="bot",
-                 entity=json.dumps(self.installation.to_bot().__dict__),
-                 enterprise_id=self.installation.enterprise_id,
-                 team_id=self.installation.team_id,
+                 entity=json.dumps(self.entr_installation.to_bot().__dict__),
+                 enterprise_id=self.entr_installation.enterprise_id,
+                 team_id=self.entr_installation.team_id,
                  user_id=None),
             call(data_type="installer",
-                 entity=json.dumps(self.installation.__dict__),
-                 enterprise_id=self.installation.enterprise_id,
-                 team_id=self.installation.team_id,
+                 entity=json.dumps(self.entr_installation.__dict__),
+                 enterprise_id=self.entr_installation.enterprise_id,
+                 team_id=self.entr_installation.team_id,
                  user_id=None),
             call(data_type="installer",
-                 entity=json.dumps(self.installation.__dict__),
-                 enterprise_id=self.installation.enterprise_id,
-                 team_id=self.installation.team_id,
-                 user_id=self.installation.user_id)
+                 entity=json.dumps(self.entr_installation.__dict__),
+                 enterprise_id=self.entr_installation.enterprise_id,
+                 team_id=self.entr_installation.team_id,
+                 user_id=self.entr_installation.user_id)
         ])
 
     @patch("multi_reaction_add.oauth.installation_store.google_cloud_storage."
            "GoogleCloudStorageInstallationStore._save_entity")
     async def test_async_save_bot(self, save_entity: Mock):
         """Test async_save_bot method"""
-        await self.installation_store.async_save_bot(bot=self.installation.to_bot())
+        await self.installation_store.async_save_bot(bot=self.entr_installation.to_bot())
         save_entity.assert_called_once_with(data_type="bot",
-            entity=json.dumps(self.installation.to_bot().__dict__),
-            enterprise_id=self.installation.enterprise_id,
-            team_id=self.installation.team_id,
+            entity=json.dumps(self.entr_installation.to_bot().__dict__),
+            enterprise_id=self.entr_installation.enterprise_id,
+            team_id=self.entr_installation.team_id,
             user_id=None)
 
     def test_save_entity_and_test_key(self):
@@ -86,38 +90,31 @@ class TestGoogleInstallationStore(unittest.IsolatedAsyncioTestCase):
         # pylint: disable=protected-access
 
         entity = "some data"
-        # test upload user data enterprise install
-        self.installation_store._save_entity(data_type="dtype",
-            entity=entity,
-            enterprise_id=self.installation.enterprise_id,
-            team_id=self.installation.team_id,
-            user_id=self.installation.user_id)
-        self.bucket.blob.assert_called_once_with(
-            f"{self.client_id}/{self.installation.enterprise_id}-{self.installation.team_id}"
-            f"/dtype-{self.installation.user_id}")
-        self.blob.upload_from_string.assert_called_once_with(entity)
+        # test upload user data enterprise install + normal workspace
+        for install in [self.entr_installation, self.team_installation]:
+            self.installation_store._save_entity(data_type="dtype",
+                entity=entity,
+                enterprise_id=install.enterprise_id,
+                team_id=install.team_id,
+                user_id=install.user_id)
+            self.bucket.blob.assert_called_once_with(
+                f"{self.client_id}/{install.enterprise_id or 'none'}-{install.team_id or 'none'}"
+                f"/dtype-{install.user_id}")
+            self.blob.upload_from_string.assert_called_once_with(entity)
 
-        self.bucket.reset_mock()
+            self.bucket.reset_mock()
 
-        # test upload user data normal install
-        self.installation_store._save_entity(data_type="dtype",
-            entity=entity,
-            enterprise_id=None,
-            team_id=self.installation.team_id,
-            user_id=self.installation.user_id)
-        self.bucket.blob.assert_called_once_with(
-            f"{self.client_id}/none-{self.installation.team_id}/dtype-{self.installation.user_id}")
+        # test upload user data enterprise install + normal workspace
+        for install in [self.entr_installation, self.team_installation]:
+            self.installation_store._save_entity(data_type="dtype",
+                entity=entity,
+                enterprise_id=install.enterprise_id,
+                team_id=install.team_id,
+                user_id=None)
+            self.bucket.blob.assert_called_once_with(
+                f"{self.client_id}/{install.enterprise_id or 'none'}-{install.team_id or 'none'}/dtype")
 
-        self.bucket.reset_mock()
-
-        # test upload bot data
-        self.installation_store._save_entity(data_type="dtype",
-            entity=entity,
-            enterprise_id=self.installation.enterprise_id,
-            team_id=self.installation.team_id,
-            user_id=None)
-        self.bucket.blob.assert_called_once_with(
-            f"{self.client_id}/{self.installation.enterprise_id}-{self.installation.team_id}/dtype")
+            self.bucket.reset_mock()
 
     async def test_async_find_bot(self):
         """Test async_find_bot method"""
@@ -127,79 +124,83 @@ class TestGoogleInstallationStore(unittest.IsolatedAsyncioTestCase):
             "bot_user_id": "buid",
             "installed_at": time.time()})
 
-        # test bot found
-        bot = await self.installation_store.async_find_bot(enterprise_id=self.installation.enterprise_id,
-            team_id=self.installation.team_id,
-            is_enterprise_install=self.installation.is_enterprise_install)
-        self.storage_client.bucket.assert_called_once_with(self.bucket_name)
-        self.bucket.blob.assert_called_once_with(
-            f"{self.client_id}/{self.installation.enterprise_id}-{self.installation.team_id}/bot")
-        self.blob.download_as_text.assert_called_once_with(encoding="utf-8")
-        self.assertIsNotNone(bot)
-        self.assertEqual(bot.bot_token, "xoxb-token")
+        # test bot found enterprise installation + normal workspace
+        for install in [self.entr_installation, self.team_installation]:
+            bot = await self.installation_store.async_find_bot(enterprise_id=install.enterprise_id,
+                team_id=install.team_id,
+                is_enterprise_install=install.is_enterprise_install)
+            self.storage_client.bucket.assert_called_once_with(self.bucket_name)
+            self.bucket.blob.assert_called_once_with(
+                f"{self.client_id}/{install.enterprise_id or 'none'}-{install.team_id or 'none'}/bot")
+            self.blob.download_as_text.assert_called_once_with(encoding="utf-8")
+            self.assertIsNotNone(bot)
+            self.assertEqual(bot.bot_token, "xoxb-token")
 
-        self.blob.reset_mock()
+            self.blob.reset_mock()
+            self.bucket.reset_mock()
 
         # test bot not found
         self.blob.download_as_text.side_effect = Exception()
-        bot = await self.installation_store.async_find_bot(enterprise_id=self.installation.enterprise_id,
-            team_id=self.installation.team_id,
-            is_enterprise_install=self.installation.is_enterprise_install)
+        bot = await self.installation_store.async_find_bot(enterprise_id=self.entr_installation.enterprise_id,
+            team_id=self.entr_installation.team_id,
+            is_enterprise_install=self.entr_installation.is_enterprise_install)
         self.blob.download_as_text.assert_called_once_with(encoding="utf-8")
         self.assertIsNone(bot)
 
     async def test_async_find_installation(self):
         """Test async_find_installation method"""
-        self.blob.download_as_text.return_value = json.dumps({"user_id": self.installation.user_id})
+        self.blob.download_as_text.return_value = json.dumps({"user_id": self.entr_installation.user_id})
+        # test installation found on enterprise install + normal workspace
+        for expect_install in [self.entr_installation, self.team_installation]:
+            actual_install = await self.installation_store.async_find_installation(
+                enterprise_id=expect_install.enterprise_id,
+                team_id=expect_install.team_id,
+                user_id=expect_install.user_id,
+                is_enterprise_install=expect_install.is_enterprise_install)
+            self.storage_client.bucket.assert_called_once_with(self.bucket_name)
+            self.bucket.blob.assert_called_once_with(
+                f"{self.client_id}/{expect_install.enterprise_id or 'none'}-{expect_install.team_id or 'none'}/"
+                f"installer-{expect_install.user_id}")
+            self.blob.download_as_text.assert_called_once_with(encoding="utf-8")
+            self.assertIsNotNone(actual_install)
+            self.assertEqual(actual_install.user_id, self.entr_installation.user_id)
 
-        # test installation found
-        installation = await self.installation_store.async_find_installation(
-            enterprise_id=self.installation.enterprise_id,
-            team_id=self.installation.team_id,
-            user_id=self.installation.user_id,
-            is_enterprise_install=self.installation.is_enterprise_install)
-        self.storage_client.bucket.assert_called_once_with(self.bucket_name)
-        self.bucket.blob.assert_called_once_with(
-            f"{self.client_id}/{self.installation.enterprise_id}-{self.installation.team_id}/"
-            f"installer-{self.installation.user_id}")
-        self.blob.download_as_text.assert_called_once_with(encoding="utf-8")
-        self.assertIsNotNone(installation)
-        self.assertEqual(installation.user_id, self.installation.user_id)
-
-        self.blob.reset_mock()
+            self.blob.reset_mock()
+            self.bucket.reset_mock()
 
         # test installation not found
         self.blob.download_as_text.side_effect = Exception()
-        installation = await self.installation_store.async_find_installation(
-            enterprise_id=self.installation.enterprise_id,
-            team_id=self.installation.team_id,
-            user_id=self.installation.user_id,
-            is_enterprise_install=self.installation.is_enterprise_install)
+        actual_install = await self.installation_store.async_find_installation(
+            enterprise_id=self.entr_installation.enterprise_id,
+            team_id=self.entr_installation.team_id,
+            user_id=self.entr_installation.user_id,
+            is_enterprise_install=self.entr_installation.is_enterprise_install)
         self.blob.download_as_text.assert_called_once_with(encoding="utf-8")
-        self.assertIsNone(installation)
+        self.assertIsNone(actual_install)
 
     async def test_async_delete_installation_and_test_delete_entity(self):
         """Test async_delete_installation and test_delete_entity methods"""
-
-        # test delete blob exist
         self.blob.exists.return_value = True
-        await self.installation_store.async_delete_installation(enterprise_id=self.installation.enterprise_id,
-            team_id=self.installation.team_id,
-            user_id=self.installation.user_id)
-        self.storage_client.bucket.assert_called_once_with(self.bucket_name)
-        self.bucket.blob.assert_called_once_with(
-            f"{self.client_id}/{self.installation.enterprise_id}-{self.installation.team_id}/"
-            f"installer-{self.installation.user_id}")
-        self.blob.exists.assert_called_once()
-        self.blob.delete.assert_called_once()
+        # test delete enterprise install + normal workspace when blob exists
+        for install in [self.entr_installation, self.team_installation]:
+            await self.installation_store.async_delete_installation(enterprise_id=install.enterprise_id,
+                team_id=install.team_id,
+                user_id=install.user_id)
+            self.storage_client.bucket.assert_called_once_with(self.bucket_name)
+            self.bucket.blob.assert_called_once_with(
+                f"{self.client_id}/{install.enterprise_id or 'none'}-{install.team_id or 'none'}/"
+                f"installer-{self.entr_installation.user_id}")
+            self.blob.exists.assert_called_once()
+            self.blob.delete.assert_called_once()
 
-        self.blob.reset_mock()
+            self.blob.reset_mock()
+            self.bucket.reset_mock()
 
         # test delete blob doesn't exist
         self.blob.exists.return_value = False
-        await self.installation_store.async_delete_installation(enterprise_id=self.installation.enterprise_id,
-            team_id=self.installation.team_id,
-            user_id=self.installation.user_id)
+        await self.installation_store.async_delete_installation(enterprise_id=self.entr_installation.enterprise_id,
+            team_id=self.entr_installation.team_id,
+            user_id=self.entr_installation.user_id)
         self.blob.exists.assert_called_once()
         self.blob.delete.assert_not_called()
 
@@ -207,9 +208,13 @@ class TestGoogleInstallationStore(unittest.IsolatedAsyncioTestCase):
            "GoogleCloudStorageInstallationStore._delete_entity")
     async def test_async_delete_bot(self, delete_entity: Mock):
         """Test async_delete_bot method"""
-        await self.installation_store.async_delete_bot(enterprise_id=self.installation.enterprise_id,
-            team_id=self.installation.team_id)
-        delete_entity.assert_called_once_with(data_type="bot",
-            enterprise_id=self.installation.enterprise_id,
-            team_id=self.installation.team_id,
-            user_id=None)
+        # test delete bot from enterprise install + normal workspace
+        for install in [self.entr_installation, self.team_installation]:
+            await self.installation_store.async_delete_bot(enterprise_id=install.enterprise_id,
+                team_id=install.team_id)
+            delete_entity.assert_called_once_with(data_type="bot",
+                enterprise_id=install.enterprise_id,
+                team_id=install.team_id,
+                user_id=None)
+
+            delete_entity.reset_mock()


### PR DESCRIPTION
- upgrade bolt framework to `1.18.0`
- fix bug where the app didn't return the [auth token back to Slack server](https://github.com/slackapi/bolt-python/issues/962), resulting in a:
    ```
    slack_sdk.errors.SlackApiError: The request to the Slack API failed. (url: https://www.slack.com/api/reactions.get)
    The server responded with: {'ok': False, 'error': 'not_authed'}
    ```