### PR TITLE
aiohttp 3.9.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 slack-bolt==1.18.0
 google-cloud-storage==2.7.0
 uvicorn==0.20.0
-aiohttp==3.9.3
+aiohttp==3.9.5
 starlette==0.37.1
 python-json-logger==2.0.4
 


### PR DESCRIPTION
Update `aiohttp` to `3.9.5` to fix vulnerability issues.